### PR TITLE
feat:devise関連のビューの作成とそれに伴うルートの変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'devise'
 gem 'bootstrap', '~> 4.6.0'
 gem 'jquery-rails'
 
+gem 'dotenv-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     execjs (2.9.1)
     ffi (1.16.3)
@@ -254,6 +258,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -1,0 +1,43 @@
+@import url(https://fonts.googleapis.com/css?family=Nunito);
+
+@import 'bootstrap';
+
+body {
+  margin: 0;
+  font-family: Nunito, sans-serif;
+  font-size: .9rem;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #212529;
+  text-align: left;
+  background-color: #f8fafc
+}
+
+h3, .h3 {
+  font-size: 1.575rem;
+}
+
+.navbar-brand {
+  display: inline-block;
+  padding-top: .32rem;
+  padding-bottom: .32rem;
+  margin-right: 1rem;
+  font-size: 1.125rem;
+  line-height: inherit;
+  white-space: nowrap
+}
+
+.form-control {
+  display: block;
+  width: 100%;
+  height: calc(2.19rem + 2px);
+  padding: .375rem .75rem;
+  font-size: .9rem;
+  line-height: 1.6;
+  color: #495057;
+  background-color: #fff;
+  background-clip: padding-box;
+  border: 1px solid #ced4da;
+  border-radius: .25rem;
+  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out
+}

--- a/app/assets/stylesheets/samuraimart.scss
+++ b/app/assets/stylesheets/samuraimart.scss
@@ -1,0 +1,63 @@
+.samuraimart-login-input {
+  border-radius: 2px;
+  border: solid 1px #b2b2b2;
+  background-color: #ffffff;
+}
+
+.samuraimart-check-label {
+  font-family: YuGo;
+  font-size: 12px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+.samuraimart-require-input-label {
+  border-radius: 1px;
+  background-color: #e2001b;
+}
+
+.samuraimart-require-input-label-text {
+  font-family: YuGo;
+  font-size: 14px;
+  font-weight: 500;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #ffffff;
+}
+
+.samuraimart-submit-button {
+  font-family: YuGo;
+  font-size: 14px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #b2b2b2;
+  color: #ffffff;
+  background-color: #0fbe9f;
+}
+
+.samuraimart-login-text {
+  font-family: YuGo;
+  font-size: 14px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: #0fbe9f;
+}
+
+.samuraimart-error-message {
+  width: 100%;
+  margin-top: .25rem;
+  font-size: 80%;
+  color: #e3342f
+}

--- a/app/controllers/users/mailer.rb
+++ b/app/controllers/users/mailer.rb
@@ -1,0 +1,2 @@
+class Users::Mailer < Devise::Mailer
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -28,6 +28,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def destroy
   #   super
   # end
+  
+  def verify
+  end
 
   # GET /resource/cancel
   # Forces the session data which is usually expired after sign
@@ -58,7 +61,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+    verify_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,6 +17,14 @@ class Users::SessionsController < Devise::SessionsController
   # def destroy
   #   super
   # end
+  
+  def after_sign_in_path_for(user)
+    products_path
+  end
+ 
+  def after_sign_out_path_for(user)
+    root_path
+  end
 
   protected
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,44 @@
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+      <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+        <div class="container">
+          <a class="navbar-brand" href="/">Ruby on Rails</a>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+
+          <div class="collapse navbar-collapse" id="navbarSupportedContent">
+              <ul class="navbar-nav ml-auto">
+              <% if user_signed_in? %>
+                <li class="nav-item dropdown">
+                  <%= link_to "#", id: "navbarDropdown", class: "nav-link dropdown-toggle",
+                  role: "button", data: { toggle: "dropdown" }, aria: { haspopup: "true", expanded: "false" } do %>
+                      <%= current_user.name %> <span class="caret"></span>
+                  <% end %>
+
+                  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                    <%= link_to "ログアウト", logout_path, method: :delete, class: "dropdown-item" %>                    
+                  </div>
+                </li>
+              <% else %>
+                <li class="nav-item">
+                  <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+                </li>
+                <li class="nav-item">
+                  <%= link_to "登録", new_user_registration_path, class: "nav-link" %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </nav>
+    </header>
+    <main class="py-4 mb-5">
+      <% if notice %><p class="alert alert-warning"><%= notice %></div><% end %>
+      <% if alert %><p class="alert alert-danger"><%= alert %></p><% end %>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
-<p>Welcome <%= @email %>!</p>
+<p>こんにちは !</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>ユーザー登録を完了してください。</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'メールアドレス確認', controller: 'users/confirmations', action: 'create', confirmation_token: @token %></p>
+
+<p>心当たりがない場合は、本メッセージは破棄してください。</p>
+
+<p>Ruby on Rails</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの再設定がリクエストされました。 下のリンクをクリックしてパスワードを再設定してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードの再設定', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>心当たりがない場合は、メッセージは破棄してください。</p>
+<p>上記のリンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。</p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,41 @@
-<h2>Change your password</h2>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5">
+      <h3 class="mt-3 mb-3">パスワード再設定</h3>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+      <hr>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <div class="form-group">
+
+          <%= f.hidden_field :reset_password_token %>
+          <%=
+            f.password_field :password,
+            class: "form-control #{"is-invalid" if resource.errors.messages[:password].present? } samuraimart-login-input",
+            autofocus: "true",
+            autocomplete: "new-password",
+            placeholder: "新しいパスワード"
+          %>
+          <% if resource.errors.messages[:email].present? %>
+          <span class="samuraimart-error-message">
+            <strong><%= resource.errors.full_messages_for(:email).first %></strong>
+          </span>
+          <% end %>
+        </div>
+
+        <div class="form-group">
+            <%=
+              f.password_field :password_confirmation,
+              class: "form-control samuraimart-login-input",
+              autocomplete: "new-password",
+              placeholder: "新しいパスワード（確認用）"
+            %>
+        </div>
+
+        <div class="form-group">
+          <%=  f.submit "パスワードリセット", class: "mt-3 btn samuraimart-submit-button w-100" %>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,36 @@
-<h2>Forgot your password?</h2>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5">
+      <h3 class="mt-3 mb-3">パスワード再設定</h3>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+      <p>
+        ご登録時のメールアドレスを入力してください。<br>
+        パスワード再発行用のメールをお送りします。
+      </p>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <hr>
+
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <div class="form-group">
+        <%=
+          f.email_field :email,
+          class: "form-control #{"is-invalid" if resource.errors.messages[:email].present? } samuraimart-login-input",
+          autofocus: "true",
+          autocomplete: "email",
+          placeholder: "メールアドレス"
+        %>
+
+        <% if resource.errors.messages[:email].present? %>
+          <span class="samuraimart-error-message">
+            <strong><%= resource.errors.full_messages_for(:email).first %></strong>
+          </span>
+        <% end %>
+      </div>
+
+      <div class="form-group">
+        <%=  f.submit "送信", class: "btn samuraimart-submit-button w-100" %>
+      </div>
+      <% end %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,29 +1,158 @@
-<h2>Sign up</h2>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5">
+      <h3 class="mt-3 mb-3">新規会員登録</h3>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+        <hr>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <div class="form-group row">
+
+          <%= f.label :name, "", class: "col-md-5 col-form-label text-md-left" do %>
+            氏名
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.text_field :name,
+              class: "form-control #{"is-invalid" if resource.errors.messages[:name].present? } samuraimart-login-input",
+              autofocus: "true",
+              required: "",
+              autocomplete: "name",
+              placeholder: "侍 太郎"
+            %>
+
+            <% if resource.errors.messages[:name].present? %>
+              <span class="samuraimart-error-message">
+                <strong><%= resource.errors.full_messages_for(:name).first %></strong>
+              </span>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :email, "", class: "col-md-5 col-form-label text-md-left" do %>
+          メールアドレス
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.email_field :email,
+              class: "form-control #{"is-invalid" if resource.errors.messages[:email].present? } samuraimart-login-input",
+              autofocus: "true",
+              required: "",
+              autocomplete: "email",
+              placeholder: "メールアドレス"
+            %>
+
+            <% if resource.errors.messages[:email].present? %>
+              <span class="samuraimart-error-message">
+                <strong><%= resource.errors.full_messages_for(:email).first %></strong>
+              </span>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :postal_code, "", class: "col-md-5 col-form-label text-md-left" do %>
+          郵便番号
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.text_field :postal_code,
+              class: "form-control #{"is-invalid" if resource.errors.messages[:postal_code].present? } samuraimart-login-input",
+              required: "",
+              placeholder: "150-0043"
+            %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :address, "", class: "col-md-5 col-form-label text-md-left" do %>
+          住所
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.text_field :address,
+              class: "form-control #{"is-invalid" if resource.errors.messages[:address].present? } samuraimart-login-input",
+              required: "",
+              placeholder: "東京都渋谷区道玄坂２丁目１１−１"
+            %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :phone, "", class: "col-md-5 col-form-label text-md-left" do %>
+          電話番号
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.text_field :phone,
+              class: "form-control #{"is-invalid" if resource.errors.messages[:phone].present? } samuraimart-login-input",
+              required: "",
+              placeholder: "03-5790-9039"
+            %>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <%= f.label :password, "", class: "col-md-5 col-form-label text-md-left" do %>
+          パスワード
+            <span class="ml-1 samuraimart-require-input-label">
+              <span class="samuraimart-require-input-label-text">必須</span>
+            </span>
+          <% end %>
+
+          <div class="col-md-7">
+            <%=
+              f.password_field :password,
+              class: "form-control #{ "is-invalid" if resource.errors.messages[:password].present? } samuraimart-login-input",
+              autofocus: "true"
+            %>
+            <% if resource.errors.messages[:password].present? %>
+            <span class="samuraimart-error-message">
+              <strong><%= resource.errors.full_messages_for(:password).first %></strong>
+            </span>
+            <% end %>
+            </div>
+          </div>
+
+        <div class="form-group row">
+          <%= f.label :password_confirmation, "", class: "col-md-5 col-form-label text-md-left" do %>
+          <% end %>
+          <div class="col-md-7">
+            <%=
+              f.password_field :password_confirmation,
+              class: "form-control samuraimart-login-input",
+              autocomplete: "new-password"
+            %>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <button type="submit" class="btn samuraimart-submit-button w-100">
+            アカウント作成
+          </button>
+        </div>
+      <% end %>
+    </div>
   </div>
-
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/registrations/verify.html.erb
+++ b/app/views/users/registrations/verify.html.erb
@@ -1,0 +1,22 @@
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5">
+      <h3 class="text-center">会員登録ありがとうございます！</h3>
+
+      <p class="text-center">
+        現在、仮会員の状態です。
+      </p>
+
+      <p class="text-center">
+        ただいま、ご入力いただいたメールアドレス宛に、ご本人様確認用のメールをお送りしました。
+      </p>
+
+      <p class="text-center">
+        メール本文内のURLをクリックすると本会員登録が完了となります。
+      </p>
+      <div class="text-center">
+        <%= link_to "トップページへ", root_path, class: "btn samuraimart-submit-button w-50 text-white" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,63 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-5">
+      <h3 class="mt-3 mb-3">ログイン</h3>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <hr>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+        <div class="form-group">
+          <%=
+            f.email_field :email,
+            class: "form-control #{"is-invalid" if alert } samuraimart-login-input",
+            autofocus: "true",
+            required: "required",
+            autocomplete: "email",
+            placeholder: "メールアドレス"
+          %>
+          <% if alert %>
+          <span class="samuraimart-error-message">
+            <strong>メールアドレスが正しくない可能性があります。</strong>
+          </span>
+          <% end %>
+        </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+        <div class="form-group">
+          <%=
+            f.password_field :password,
+            class: "form-control #{"is-invalid" if alert } samuraimart-login-input",
+            autofocus: "true",
+            autocomplete: "current-password",
+            placeholder: "パスワード"
+          %>
+
+          <% if alert %>
+          <span class="samuraimart-error-message">
+            <strong>パスワードが正しくない可能性があります。</strong>
+          </span>
+          <% end %>
+        </div>
+
+        <div class="form-group">
+          <div class="form-check">
+            <%=  f.check_box :remember_me, class: "form-check-input" %>
+            <%=  f.label :remember_me, "次回から自動的にログインする", class: "form-check-label samuraimart-check-label w-100" %>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <%=  f.submit "ログイン", class: "mt-3 btn samuraimart-submit-button w-100" %>
+        </div>
+
+        <%= link_to "パスワードをお忘れの場合", new_user_password_path, class: "btn btn-link mt-3 d-flex justify-content-center samuraimart-login-text" %>
+        <% end %>
+
+      <hr>
+
+      <div class="form-group">
+        <%= link_to "新規登録", new_user_registration_path, class: "btn btn-link mt-3 d-flex justify-content-center samuraimart-login-text" %>
+      </div>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,10 +10,13 @@ module Samuraimart
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,22 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  Rails.application.configure do
+    # default url
+    config.action_mailer.default_url_options = {
+      protocol: 'https',
+      host: ENV["CLOUD9_APP_ROOT_URL"]
+    }
+    # mail setting
+    config.action_mailer.raise_delivery_errors = true
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      :address => "smtp.gmail.com",
+      :port => 587,
+      :user_name => ENV["GMAIL_ADDRESS"],
+      :password => ENV["GMAIL_2FACTOR_PASSWORD"],
+      :authentication => :plain,
+      :enable_starttls_auto => true
+    }
+  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,10 +24,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV["GMAIL_ADDRESS"]
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Users::Mailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,62 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,18 @@
 Rails.application.routes.draw do
+  devise_for :users, :controllers => {
+    :registrations => 'users/registrations',
+    :sessions => 'users/sessions',
+    :passwords => 'users/passwords',
+    :confirmations => 'users/confirmations',
+    :unlocks => 'users/unlocks',
+  }
 
+  devise_scope :user do
+    root :to => "users/sessions#new"
+    get "signup", :to => "users/registrations#new"
+    get "verify", :to => "users/registrations#verify"
+    get "login", :to => "users/sessions#new"
+    delete "logout", :to => "users/sessions#destroy"
+  end
+  resources :products
+end

--- a/db/migrate/20240131000518_devise_create_users.rb
+++ b/db/migrate/20240131000518_devise_create_users.rb
@@ -26,10 +26,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       # t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_30_010054) do
+ActiveRecord::Schema.define(version: 2024_01_31_000518) do
 
   create_table "categories", force: :cascade do |t|
     t.string "major_category_name"
@@ -28,6 +28,26 @@ ActiveRecord::Schema.define(version: 2024_01_30_010054) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_products_on_category_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "postal_code", null: false
+    t.string "address", null: false
+    t.string "phone", null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
 end


### PR DESCRIPTION
## やったこと　

#### 下記ビューファイルを編集しました
- `app/views/users/sessions/new.html.erb`　：ログイン画面
- `app/views/layouts/application.html.erb`　：ヘッダー追加しました
- `app/views/users/passwords/new.html.erb`　：パスワード再設定のメール送信画面
- `/app/views/users/passwords/edit.html.erb`　：パスワード再設定画面
- `app/views/users/registrations/new.html.erb`　：アカウント作成画面
- `app/views/users/mailer/confirmation_instructions.html.erb`　：アカウント作成時に送信するメール本文変更
- `app/views/users/mailer/reset_password_instructions.html.erb`　：パスワードリセット時に送信するメール本文変更
- `app/views/users/registrations/verify.html.erb`　：メールの送信完了を知らせる画面

#### 下記scssファイルを新規作成、編集しました
- `app/assets/stylesheets/app.scss`
- `app/assets/stylesheets/samuraimart.scss`

#### `config/application.rb`編集
レイアウト崩れを防ぐために、`field_with_errors`というclassを付与しないように変更

#### アカウント作成時にメールを送信して認証させる設定もしてます
- `config/environments/development.rb`編集
- `dotenv-rails`インストール
- `.env`ファイルを作成し環境変数を定義
- `User`モデルに合わせて、`Devise::Mailer`を継承した独自の`Mailer`を作成(`app/controllers/users/mailer.rb`)
- `app/models/user.rb`とマイグレーションファイルに`confirmable`を追加

#### i18nで日本語化
- `config/application.rb`に`config.i18n.default_locale = :ja`追加
- `config/locales/devise.ja.yml`新規作成、編集

#### アカウント作成後のリダイレクト先を変更する
- `routes.rb`に確認画面のルートを追加
- `app/controllers/users/registrations_controller.rb`に自動的に`/verify`の画面に遷移するように設定

#### view画像
* ログイン画面

<img width="1509" alt="スクリーンショット 2024-02-01 12 50 50" src="https://github.com/yume-ebina/SAMURAIMART/assets/147839715/aab992b3-481d-469b-b316-37034f0b6acd">

* サインアップ画面

![スクリーンショット 2024-02-01 15 13 04](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/ea142931-3f00-4b1e-91c7-fb0cc1eeed48)

* パスワード再設定メールアドレス入力画面
![スクリーンショット 2024-02-01 15 18 04](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/78155484-13cd-4c75-b899-abc013479d18)

* パスワード再設定用パスワード入力画面
<img width="1507" alt="スクリーンショット 2024-02-01 12 52 48" src="https://github.com/yume-ebina/SAMURAIMART/assets/147839715/793f05f4-04d6-4729-8c49-18f33558fe24">

* サインアップ後の画面
![スクリーンショット 2024-02-01 11 18 56](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/e8edcb99-4610-4572-9afc-c27da85c5ab4)

* ログイン後の商品一覧画面
<img width="1510" alt="スクリーンショット 2024-02-01 11 41 23" src="https://github.com/yume-ebina/SAMURAIMART/assets/147839715/010d8d08-bd3c-4710-9997-029464b7b329">


## できるようになること（ユーザ目線）

* ログイン
* パスワード変更(リンクが添付されてるメールが届きます)
* 新規アカウント作成(リンクが添付されてるメールが届きます)
* ナビゲーションバー左上のロゴ(?)からプロダクト一覧へ遷移
* ヘッダーのログイン、登録ボタン使えるようになりました


## 今回の実装でできなくなったこと（ユーザ目線）

* なし


## 動作確認

* 特にエラーは発生してません


## その他
* ログアウト機能はまだ使えません