### PR TITLE
feat:マイページからお気に入り商品を閲覧できるように変更

### DIFF
--- a/app/assets/stylesheets/samuraimart.scss
+++ b/app/assets/stylesheets/samuraimart.scss
@@ -207,3 +207,8 @@ label {
   cursor: pointer;
   cursor: hand;
 }
+
+.samuraimart-favorite-add-cart {
+  border-radius: 2px;
+  background-color: #0fbe9f;
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only: [:show, :edit, :update, :destroy]
+  before_action :set_product, only: [:show, :edit, :update, :destroy, :favorite]
   PER = 16
 
   def index
@@ -47,6 +47,11 @@ class ProductsController < ApplicationController
   def destroy
     @product.destroy
     redirect_to products_url
+  end
+  
+  def favorite
+    current_user.toggle_like!(@product)
+    redirect_to product_url @product
   end
   
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user
+  before_action :authenticate_user!
   def edit
   end
 
@@ -7,13 +8,17 @@ class UsersController < ApplicationController
     @user.update_without_password(user_params)
     redirect_to mypage_users_url
   end
-
+  
   def mypage
     @user = current_user
   end
   
   def edit_address
     
+  end
+  
+  def favorite
+    @favorites = @user.likees(Product)
   end
   
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,31 +1,25 @@
 class Product < ApplicationRecord
   belongs_to :category
   has_many :reviews
+  acts_as_likeable
   
   PER = 16
+  
+  scope :display_list, -> (page) { page(page).per(PER) }
  
-  def self.display_list(page)
-    page(page).per(PER)
-  end
-  
-  def self.on_category(category)
-    where(category_id: category)
-  end
-  
-  def self.sort_order(order)
-     order(order)
-  end
-  
-  def self.category_products(category, page)
+  scope :on_category, -> (category) { where(category_id: category) }
+  scope :sort_order, -> (order) { order(order) }
+ 
+  scope :category_products, -> (category, page) { 
     on_category(category).
     display_list(page)
-  end
-  
-  def self.sort_products(sort_order, page)
+  }
+ 
+  scope :sort_products, -> (sort_order, page) {
     on_category(sort_order[:sort_category]).
     sort_order(sort_order[:sort]).
     display_list(page)
-  end
+  }
 
   scope :sort_list, -> { 
     {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
+         
+  acts_as_liker
+         
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,6 +23,11 @@
             <i class="fas fa-user mr-1"></i><label>マイページ</label>
           <% end %>
         </li>
+        <li class="nav-item mr-5">
+          <%= link_to mypage_favorite_users_path, class: "nav-link" do %>
+            <i class="far fa-heart"></i>
+          <% end %>
+        </li>
       <% else %>
         <li class="nav-item mr-5">
           <%= link_to new_user_registration_path, class: "nav-link" do %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -37,8 +37,8 @@
               <% end %>
             </div>
             <div class="col-5">
-              <%= link_to "#", class: "btn samuraimart-favorite-button text-dark w-100" do %>
-                <i class="fa fa-heart"></i>お気に入り
+              <%= link_to favorite_product_path, class: "btn samuraimart-favorite-button text-favorite w-100" do %>
+                <i class="fa fa-heart"></i><%= current_user.likes?(@product) ? "お気に入り解除" : "お気に入り" %>
               <% end %>
             </div>
           </div>

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -1,0 +1,34 @@
+<div class="container  d-flex justify-content-center mt-3">
+  <div class="w-75">
+    <h1>お気に入り</h1>
+
+    <hr>
+
+    <div class="row">
+      <% @favorites.each do |favorite| %>
+      <div class="col-md-8 mt-2">
+        <div class="d-inline-flex">
+          <%= link_to product_path(favorite), class: "w-25" do %>
+            <%= image_tag "/images/dummy.png", class: "img-fuild w-100" %>
+          <% end %>
+          <div class="container mt-3">
+            <h5 class="w-100 samuraimart-favorite-item-text"><%= favorite.name %></h5>
+            <h6 class="w-100samuraimart-favorite-item-text">￥<%= favorite.price %></h6>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-2 d-flex align-items-center justify-content-end">
+        <%= link_to product_path(favorite), class: "samuraimart-favorite-item-delete" do %>
+          削除
+        <% end %>
+      </div>
+      <div class="col-md-2 d-flex align-items-center justify-content-end">
+        <button type="submit" class="btn samuraimart-favorite-add-cart text-white w-100">カートに入れる</button>
+      </div>
+      <% end %>
+    </div>
+
+    <hr>
+
+  </div>
+</div>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -73,7 +73,6 @@
     </div>
     
     <hr>
-
     <div class="container">
       <div class="d-flex justify-content-between">
         <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,10 +22,14 @@ Rails.application.routes.draw do
       get "mypage/edit", :to => "users#edit"
       get "mypage/address/edit", :to => "users#edit_address"
       put "mypage", :to => "users#update"
+      get  "mypage/favorite", :to => "users#favorite"
     end
   end
   
   resources :products do
+    member do
+      get :favorite
+    end
     resources :reviews, only: [:create]
   end
 end


### PR DESCRIPTION
## やったこと　
- `app/views/users/favorite.html.erb`新規ビューファイル作成
- 下記コントローラー編集
- `app/controllers/products_controller.rb`
- `app/controllers/ users_controller.rb`
- デザイン編集　`app/assets/stylesheets/samuraimart.scss`
- ヘッダーのハートアイコンからお気に入り一覧に飛べるよう変更


## できるようになること（ユーザ目線）

* お気に入り商品の閲覧
　削除は商品詳細ページのお気に入りボタンを押すことでお気に入り解除するシステムになってます
<img width="1505" alt="スクリーンショット 2024-02-18 23 45 47" src="https://github.com/yume-ebina/SAMURAIMART/assets/147839715/6f5a5249-33ca-46cc-ae29-54884ff0cb85">

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 特にエラーは発生してません

## その他

*お気に入り機能とは関係ありませんが `app/models/product.rb`のクラスメソッドをスコープに変更してます
