### PR TITLE
feat:顧客管理画面の実装

### DIFF
--- a/app/assets/javascripts/dashboard/users.coffee
+++ b/app/assets/javascripts/dashboard/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/dashboard/users.scss
+++ b/app/assets/stylesheets/dashboard/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dashboard/users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/dashboard/users_controller.rb
+++ b/app/controllers/dashboard/users_controller.rb
@@ -1,0 +1,21 @@
+class Dashboard::UsersController < ApplicationController
+  before_action :authenticate_admin!
+  layout "dashboard/dashboard"
+  
+  def index
+    if params[:keyword].present?
+      @keyword = params[:keyword].strip
+      @users = User.search_information(@keyword).display_list(params[:pages])
+    else
+      @keyword = ""
+      @users = User.display_list(params[:pages])
+    end
+  end
+ 
+  def destroy
+     user = User.find(params[:id])
+     deleted_flg = User.switch_flg(user.deleted_flg)
+     user.update(deleted_flg: deleted_flg)
+     redirect_to dashboard_users_path
+  end
+end

--- a/app/helpers/dashboard/users_helper.rb
+++ b/app/helpers/dashboard/users_helper.rb
@@ -1,0 +1,2 @@
+module Dashboard::UsersHelper
+end

--- a/app/models/concerns/switch_flg.rb
+++ b/app/models/concerns/switch_flg.rb
@@ -1,0 +1,5 @@
+module SwitchFlg
+  def switch_flg(column_of_obj)
+    column_of_obj ? false : true
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :reviews
+  extend DisplayList
+  extend SwitchFlg
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -17,4 +19,8 @@ class User < ApplicationRecord
     clean_up_passwords
     result
   end
+  
+  scope :search_information, -> (keyword) { 
+    where("name LIKE :keyword OR id LIKE :keyword OR email LIKE :keyword OR address LIKE :keyword OR postal_code LIKE :keyword OR phone LIKE :keyword", keyword: "%#{keyword}%")
+  }
 end

--- a/app/views/dashboard/users/index.html.erb
+++ b/app/views/dashboard/users/index.html.erb
@@ -1,0 +1,49 @@
+<div class="w-75">
+
+  <h1>顧客一覧</h1>
+
+ <div class="w-75">
+   <%= form_with url: dashboard_users_path, method: :get, local: true do |f| %>
+     <div class="d-flex flex-inline form-group">
+       <div class="d-flex align-items-center">
+         ID・氏名など
+       </div>
+       <%= f.text_area :keyword, value: @keyword, class: "form-controll ml-2 w-50" %>
+     </div>
+     <%= f.submit "検索", class: "btn samuraimart-submit-button" %>
+   <% end %>
+ </div>
+
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">ID</th>
+        <th scope="col">名前</th>
+        <th scope="col">メールアドレス</th>
+        <th scope="col">電話番号</th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+      <tr>
+        <th scope="row"><%= user.id %></td>
+        <td><%= user.name %></td>
+        <td><%= user.email %></td>
+        <td><%= user.phone %></td>
+        <td>
+          <%= form_with model: user, url: dashboard_user_path(user), local: true, method: :delete do |f| %>
+            <% if user.deleted_flg %>
+              <%= f.submit "復帰", class: "btn dashboard-delete-link" %>
+            <% else %>
+              <%= f.submit "削除", class: "btn dashboard-delete-link" %>
+            <% end %>
+          <% end %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @users%>
+</div>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -21,7 +21,9 @@
 
   <h2>顧客管理</h2>
   <div class="d-flex flex-column">
-    <label class="samuraimart-sidebar-category-label">顧客一覧</label>
+    <label class="samuraimart-sidebar-category-label">
+      <%= link_to "顧客一覧", dashboard_users_path %>
+    </label>
     <label class="samuraimart-sidebar-category-label">顧客登録</label>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :major_categories, except: [:new]
     resources :categories, except: [:new]
     resources :products, except: [:show]
+    resources :users, only: [:index, :destroy]
   end
   
   devise_for :users, :controllers => {

--- a/db/migrate/20240228224736_add_deleted_flag_to_users.rb
+++ b/db/migrate/20240228224736_add_deleted_flag_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeletedFlagToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :deleted_flg, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_28_024132) do
+ActiveRecord::Schema.define(version: 2024_02_28_224736) do
 
   create_table "admins", force: :cascade do |t|
     t.string "name", null: false
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2024_02_28_024132) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "deleted_flg", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/dashboard/users_controller_test.rb
+++ b/test/controllers/dashboard/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dashboard::UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと　
- 管理者がカテゴリの管理をできるよう下記ファイルを編集
- 顧客が削除済みか管理するために`users`テーブルに`deleted_flg`カラム追加

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/dashboard/users_controller.rb` | ダッシュボードの顧客用コントローラ新規作成 |
| `app/views/dashboard/categories/index.html.erb` | 顧客一覧画面新規作成 |
| `app/models/user.rb` | 検索機能を追加 |
| `config/routes.rb` | ルート編集 |
| `app/models/concerns/switch_flg.rb` | `user`が削除されているか状態を管理するモジュール作成 |
| `app/assets/stylesheets/samuraimart.scss`| デザイン編集 |


## できるようになること（ユーザ目線）

* 管理者が顧客を検索できるようになりました
* 管理者が顧客を削除、復帰させることができるようになりました
* サイドバーから「顧客管理」へ飛べるようになりました
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/f785f06d-0dcf-4803-95f8-dc6533e24e2b)
* 削除ボタンを押すと復帰ボタンに切り替わる
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/f91131b8-f983-40f8-bad6-323f63399507)


## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
