### PR TITLE
feat:ユーザーの退会機能を追加

### DIFF
--- a/app/assets/stylesheets/samuraimart.scss
+++ b/app/assets/stylesheets/samuraimart.scss
@@ -261,3 +261,9 @@ label {
 td{
   width: 15%;
 }
+
+//退会ボタン
+.samuraimart-delete-submit-button {
+  border-radius: 2px;
+  background-color: #d94b0e;
+}

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,8 @@
 
 class Users::SessionsController < Devise::SessionsController
   before_action :configure_sign_in_params, only: [:create]
-
+  before_action :reject_user, only: [:create]
+  
   # GET /resource/sign_in
   # def new
   #   super
@@ -32,5 +33,15 @@ class Users::SessionsController < Devise::SessionsController
   def configure_sign_in_params
     devise_parameter_sanitizer.permit(
       :sign_in, keys: [ :name, :postal_code, :address, :phone, :email, :password, :password_confirmation ])
+  end
+  
+  def reject_user
+    @user = User.find_by(email: params[:user][:email].downcase)
+    if @user
+      if @user.deleted_flg?
+        set_flash_message! :notice, :deleted
+        redirect_to new_user_session_path
+      end
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,6 +34,12 @@ class UsersController < ApplicationController
   def favorite
     @favorites = @user.likees(Product)
   end
+  
+  def destroy
+    @user.deleted_flg = User.switch_flg(@user.deleted_flg)
+    @user.update(deleted_flg: @user.deleted_flg)
+    redirect_to root_url
+  end
 
   private
     def set_user

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -110,6 +110,42 @@
       <hr>
 
       <% end %>
+      
+      <div class="d-flex justify-content-end">
+        <%= form_with model: @user, url: mypage_delete_users_path, method: :delete, local: true do |f| %>
+        <div class="btn dashboard-delete-link" data-toggle="modal" data-target="#delete-user-confirm-modal">退会する</div>
+ 
+          <div 
+          class="modal fade" 
+          id="delete-user-confirm-modal" 
+          data-backdrop="static" 
+          data-keyboard="false" 
+          tabindex="-1" 
+          role="dialog" 
+          aria-labelledby="staticBackdropLabel" 
+          aria-hidden="true"
+          >
+            <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title" id="staticBackdropLabel"><label>本当に退会しますか？</label></h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+                <div class="modal-body">
+                  <p class="text-center">一度退会するとデータはすべて削除され復旧はできません。</p>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn dashboard-delete-link" data-dismiss="modal">キャンセル</button>
+                  <button type="submit" class="btn samuraimart-delete-submit-button text-white">退会する</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -46,6 +46,7 @@ ja:
       signed_in: 'ログインしました。'
       signed_out: 'ログアウトしました。'
       already_signed_out: '既にログアウト済みです。'
+      deleted: '既に退会済みです。'
     unlocks:
       send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
       send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ resource :users, only: [:edit, :update] do
     get "mypage/edit_password", :to =>"users#edit_password"
     put "mypage/password", :to => "users#update_password"
     get  "mypage/favorite", :to => "users#favorite"
+    delete "mypage/delete", :to => "users#destroy"
   end
 end
 


### PR DESCRIPTION
## やったこと　
- ユーザーが退会できる機能を実装

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/users_controller.rb` | ユーザーコントローラに`destroy`メソッド追加 |
|  `app/controllers/users/sessions_controller.rb` | `devise`のコントローラに編集 |
| `app/views/users/edit.html.erb` | 退会画面追加 |
| `app/views/dashboard/categories/edit.html.erb` | カテゴリ編集画面新規作成 |
| `config/routes.rb` | ルート編集 |
| `app/assets/stylesheets/samuraimart.scss`| デザイン編集 |


## できるようになること（ユーザ目線）

* ユーザーが退会できるようになりました
* 退会ボタン実装
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/263c0650-c8a2-421a-902d-8943a3fffec1)

* 退会後にログインしようとするとフラッシュ出現し、ログインできない仕様
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/33f18468-07fb-4794-9b7c-92b5092ef342)


## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 退会後にログアウトされない仕様に違和感ありますが一旦このまま進めてます、、

## その他

- なし
