### PR TITLE
feat:トップページにおすすめ商品を表示

### DIFF
--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -1,4 +1,7 @@
 class WebController < ApplicationController
+  
+  PRODUCTS_PER_PAGE = 4
+  
   def index
     if sort_params.present?
       @category = Category.request_category(sort_params[:sort_category])
@@ -12,6 +15,7 @@ class WebController < ApplicationController
  
     @major_category_names = Category.major_categories
     @categories = Category.all
+    @recently_products = Product.recently_products(PRODUCTS_PER_PAGE)
   end
 
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -33,6 +33,11 @@ class Product < ApplicationRecord
       "出品の新しい順" => "updated_at desc"
     }
   }
+  
+  scope :recently_products, -> (number) {
+    order(created_at: "desc").take(number)
+  }
+  
   def reviews_new
     reviews.new
   end

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -51,61 +51,21 @@
 
       <h1>新着商品</h1>
       <div class="row">
+        <% @recently_products.each do |recently_product| %>
         <div class="col-3">
-          <%= link_to "#", class: "img-thumbnail" do %>
-            <%= image_tag "/images/panasonic.png", class: "img-thumbnail"%>
+          <%= link_to product_path(recently_product) do %>
+            <%= image_tag "/images/dummy.png", class: "img-thumbnail" %>
           <% end %>
           <div class="row">
             <div class="col-12">
-              <p class="samuraimart-product-label mt-2">
-                掃除機本体 Panasonic<br>
-                <label>￥15000</label>
+              <p class="samuraimart-product-level mt-2">
+                <%= recently_product.name %>
+                <label>￥<%= recently_product.price %></label>
               </p>
             </div>
           </div>
         </div>
-
-        <div class="col-3">
-          <%= link_to "#", class: "img-thumbnail" do %>
-            <%= image_tag "/images/sofa.png", class: "img-thumbnail"%>
-          <% end %>
-          <div class="row">
-            <div class="col-12">
-              <p class="samuraimart-product-label mt-2">
-              3人掛けソファー ブラウン<br>
-              <label>￥35000</label>
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-3">
-        <%= link_to "#", class: "img-thumbnail" do %>
-          <%= image_tag "/images/item.png", class: "img-thumbnail"%>
-        <% end %>
-        <div class="row">
-          <div class="col-12">
-            <p class="samuraimart-product-label mt-2">
-              柔軟剤 詰め替え 2L<br>
-              <label>￥1000</labiel>
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-3">
-        <%= link_to "#", class: "img-thumbnail" do %>
-          <%= image_tag "/images/goods.png", class: "img-thumbnail"%>
-        <% end %>
-        <div class="row">
-          <div class="col-12">
-            <p class="samuraimart-product-label mt-2">
-              食器 カトラリーセット1組<br>
-              <label>￥2000</label>
-            </p>
-          </div>
-        </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## やったこと　
- トップページに新着商品を4つ表示されるように編集しました

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/web_controller.rb` | トップページのコントローラ新規作成 |
| `app/views/web/index.html.erb` | トップページのビュー編集 |
| `app/models/product.rb` | モデルにメソッド追加 |


## できるようになること（ユーザ目線）

* トップページに4つの新着商品が新しく追加した順で表示されるようになりました
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/24031592-aab9-4e47-9ddf-c2f4873e2579)


## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
