### PR TITLE
feat:おすすめ商品の管理、トップ画面に表示できるよう実装

### DIFF
--- a/app/controllers/dashboard/products_controller.rb
+++ b/app/controllers/dashboard/products_controller.rb
@@ -52,6 +52,6 @@ class Dashboard::ProductsController < ApplicationController
     end
 
     def product_params
-      params.require(:product).permit(:name, :description, :price, :category_id)
+      params.require(:product).permit(:name, :description, :price, :category_id, :recommended_flag)
     end
 end

--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -1,6 +1,7 @@
 class WebController < ApplicationController
   
-  PRODUCTS_PER_PAGE = 4
+  RECENTLY_PRODUCTS_PER_PAGE = 4
+  RECOMMEND_PRODUCTS_PER_PAGE = 3
   
   def index
     if sort_params.present?
@@ -15,7 +16,9 @@ class WebController < ApplicationController
  
     @major_category_names = Category.major_categories
     @categories = Category.all
-    @recently_products = Product.recently_products(PRODUCTS_PER_PAGE)
+    @recently_products = Product.recently_products(RECENTLY_PRODUCTS_PER_PAGE)
+    @recommend_products = Product.recommend_products(RECOMMEND_PRODUCTS_PER_PAGE)
+    
   end
 
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -38,6 +38,10 @@ class Product < ApplicationRecord
     order(created_at: "desc").take(number)
   }
   
+  scope :recommend_products, -> (number) { 
+    where(recommended_flag: true).take(number)
+    }
+  
   def reviews_new
     reviews.new
   end

--- a/app/views/dashboard/products/edit.html.erb
+++ b/app/views/dashboard/products/edit.html.erb
@@ -21,6 +21,11 @@
       <%= f.label :category_id, "カテゴリ", class: "col-2 d-flex justify-content-start" %>
       <%= f.select :category_id, Category.all.map { |category| [category.name, category.id] }, {}, class: "form-control" %>
     </div>
+    
+    <div class="form-inline mt-4 mb-4 row">
+      <%= f.label :recommended_flag, "オススメ?", class: "col-2 d-flex justify-content-start" %>
+      <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
+     </div>
 
     <%= f.submit "更新", class: "w-25 btn samuraimart-submit-button" %>
   <% end %>

--- a/app/views/dashboard/products/new.html.erb
+++ b/app/views/dashboard/products/new.html.erb
@@ -23,6 +23,11 @@
       <%= f.label "カテゴリ", class: "col-2 d-flex justify-content-start" %>
       <%= f.collection_select(:category_id, @categories, :id, :name, {}, class: "form-control") %>
     </div>
+    
+    <div class="form-inline mt-4 mb-4 row ">
+      <%= f.label "オススメ?", class: "col-2 d-flex justify-content-start" %>
+      <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
+    </div>
 
     <%= f.submit "商品を登録", class:"btn samuraimart-submit-button" %>
   <% end %>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -5,48 +5,21 @@
     <div class="col-9">
       <h1>おすすめ商品</h1>
       <div class="row">
-        <div class="col-4">
-          <%= link_to "#", class: "img-thumbnail" do %>
-            <%= image_tag "/images/orange.png", class: "img-thumbnail"%>
-          <% end %>
-          <div class="row">
-             <div class="col-12">
-              <p class="samuraimart-product-label mt-2">
-                旬のオレンジ詰め合わせ<br>
-                <label>￥2000</label>
-              </p>
+        <% @recommend_products.each do |recommend_product| %>
+          <div class="col-4">
+            <%= link_to product_path(recommend_product) do %>
+              <%= image_tag "/images/dummy.png", class: "img-thumbnail" %>
+            <% end %>
+            <div class="row">
+              <div class="col-12">
+                <p class="samuraimart-product-level mt-2">
+                  <%= recommend_product.name %>
+                  <label>￥<%= recommend_product.price %></label>
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-        
-        <div class="col-4">
-          <%= link_to "#", class: "img-thumbnail" do %>
-            <%= image_tag "/images/pan.png", class: "img-thumbnail"%>
-          <% end %>
-          <div class="row">
-            <div class="col-12">
-              <p class="samuraimart-product-label mt-2">
-                フライパン20cm 鉄製 業務用<br>
-                <label>￥5000</label>
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-4">
-          <%= link_to "#", class: "img-thumbnail" do %>
-            <%= image_tag "/images/meat.png", class: "img-thumbnail"%>
-          <% end %>
-          <div class="row">
-            <div class="col-12">
-              <p class="samuraimart-product-label mt-2">
-                和牛ロース200g 2枚入り<br>
-                <label>￥8200</label>
-              </p>
-            </div>
-          </div>
-        </div>
-
+        <% end %>
       </div>
 
       <h1>新着商品</h1>

--- a/db/migrate/20240229022148_add_recommended_flag_to_products.rb
+++ b/db/migrate/20240229022148_add_recommended_flag_to_products.rb
@@ -1,0 +1,5 @@
+class AddRecommendedFlagToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :recommended_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_28_224736) do
+ActiveRecord::Schema.define(version: 2024_02_29_022148) do
 
   create_table "admins", force: :cascade do |t|
     t.string "name", null: false
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 2024_02_28_224736) do
     t.integer "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "recommended_flag", default: false
     t.index ["category_id"], name: "index_products_on_category_id"
   end
 

--- a/db/seeds/development/products_seeder.rb
+++ b/db/seeds/development/products_seeder.rb
@@ -8,7 +8,8 @@ product_ids.each do
     name: product_name,
     description: product_name,
     price: product_ids[array_number],
-    category_id: category_ids[array_number]
+    category_id: category_ids[array_number],
+    recommended_flag: false
   )
   array_number += 1
 end


### PR DESCRIPTION
## やったこと　
- 商品がおすすめかどうかチェックボックスで管理できるように実装
- トップ画面におすすめ商品が3つ表示されるよう実装

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/web_controller.rb` | トップページのコントローラ編集 |
| `app/views/web/index.html.erb` | トップページのビュー編集 |
| `app/models/product.rb` | モデルにメソッド追加 |
|  `app/views/dashboard/products/edit.html.erb` | ダッシュボードの商品編集画面にチェックボックス追加 |
| `app/views/dashboard/products/new.html.erb` | ダッシュボードの商品新規追加画面にチェックボックス追加  |
| `app/views/dashboard/categories/edit.html.erb` | カテゴリ編集画面新規作成 |

## できるようになること（ユーザ目線）

* トップページに3つのおすすめ商品が表示されるようになりました(`recommended_flag: true`の商品が表示されてます)
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/9523ca8a-50c5-4ef5-97d3-03a609d5f510)
* 管理者が商品を編集する際に「オススメ？」チェックボックスが表示されるようになりました
* `true`にするとトップページのおすすめ商品に追加されるようになりました
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/2d2d905d-21e7-4d41-ac7d-b0cf4f931923)
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/cb6b09ef-79d4-48d6-9f04-365cb0bbb5e6)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認
* 特にエラーはありませんが`recommended_flag: true`を3つまでにしておかないと4つ目を`true`にしてもトップには表示されない仕様になってます

## その他

- なし
