### PR TITLE
feat:売上一覧画面の実装

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,5 +3,16 @@ class DashboardController < ApplicationController
   layout 'dashboard/dashboard'
   
   def index
+    @sort = params[:sort]
+    @sort_list = ShoppingCart.sort_list 
+     
+    if @sort == "month"
+      sales = ShoppingCart.get_monthly_sales
+    else
+      sales = ShoppingCart.get_daily_sales
+    end
+     
+    @sales = Kaminari.paginate_array(sales).page(params[:page]).per(15)
   end
+
 end

--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -1,10 +1,84 @@
 class ShoppingCart < ApplicationRecord
-    acts_as_shopping_cart
+  acts_as_shopping_cart
     
-    scope :set_user_cart, -> (user) { user_cart = where(user_id: user.id, buy_flag: false)&.last
-                               user_cart.nil? ? ShoppingCart.create(user_id: user.id)
-                                              : user_cart }
+  scope :set_user_cart, -> (user) { user_cart = where(user_id: user.id, buy_flag: false)&.last
+                             user_cart.nil? ? ShoppingCart.create(user_id: user.id)
+                                            : user_cart }
 
+  scope :bought_carts, -> {where(buy_flag: true)}
+  
+  scope :bought_months_sqlite, -> {
+    bought_carts.order(updated_at: :desc).group("strftime('%Y-%m', updated_at, '+09:00')").pluck(:updated_at) 
+  }
+  scope :bought_days_sqlite, -> {
+    bought_carts.order(updated_at: :desc).group("strftime('%Y-%m-%d', updated_at, '+09:00')").pluck(:updated_at)
+  }
+  scope :bought_months_mysql, -> {
+    bought_carts.order(updated_at: :desc).group("date_format(updated_at + interval 9 hour, '%Y-%m')").pluck(:updated_at)
+  }
+  scope :bought_days_mysql, -> {
+    bought_carts.order(updated_at: :desc).group("date_format(updated_at + interval 9 hour, '%Y-%m-%d')").pluck(:updated_at)
+  }
+
+  scope :search_bought_carts_by_month, -> (month) { bought_carts.where(updated_at: month.all_month) }
+  scope :search_bought_carts_by_day, -> (day) { bought_carts.where(updated_at: day.all_day) }
+  
+  scope :sort_list, -> {
+     {"日別": "daily", "月別": "month"}
+   }
+  
+  def self.get_monthly_sales
+    if Rails.env.production?
+      months = bought_months_mysql
+    else
+      months = bought_months_sqlite
+    end
+     
+    array = Array.new(months.count) { Hash.new }
+     
+    months.each_with_index do |month, i|
+      monthly_sales = search_bought_carts_by_month(month)
+      total = 0
+       
+      monthly_sales.each do |monthly_sale|
+        total += monthly_sale.total.fractional / 100
+      end   
+       
+      array[i][:period] = month.strftime("%Y-%m")
+      array[i][:total] = total
+      array[i][:count] = monthly_sales.count
+     array[i][:average] = total / monthly_sales.count
+    end
+     
+    return array
+  end
+ 
+  def self.get_daily_sales
+    if Rails.env.production?
+      days = bought_days_mysql
+    else
+      days = bought_days_sqlite
+    end    
+     
+    array = Array.new(days.count) { Hash.new }
+     
+    days.each_with_index do |day, i|
+      daily_sales = search_bought_carts_by_day(day)
+      total = 0
+       
+      daily_sales.each do |daily_sale|
+        total += daily_sale.total.fractional / 100
+      end
+       
+      array[i][:period] = day.strftime("%Y-%m-%d")
+      array[i][:total] = total
+      array[i][:count] = daily_sales.count
+      array[i][:average] = total / daily_sales.count
+    end
+     
+    return array
+  end
+  
   def tax_pct
     0
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,39 @@
+<div class="w-75">
+  <% if @sort == "month" %>
+    <h1>月別売上</h1>
+  <% else %>
+    <h1>日別売上</h1>
+  <% end %>
+  <%= form_with url: dashboard_path, method: :get, local: true, class: "form-inline" do |f| %>
+    切り替え
+    <% if @sort.present? %>
+      <%= f.select :sort, @sort_list, { selected: @sort}, { onChange: "javascript: this.form.submit();", class: "form-inline ml-2" } %>
+    <% else %>
+      <%= f.select :sort, @sort_list, {}, { onChange: "javascript: this.form.submit();", class: "form-inline ml-2" } %>
+    <% end %>
+  <% end %>
+  <div class="container mt-4">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">年月日</th>
+          <th scope="col">金額</th>
+          <th scope="col">件数</th>
+          <th scope="col">平均単価</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @sales.each do |sale| %>
+          <tr>
+            <td><%= sale[:period] %></td>
+            <td><%= sale[:total] %></td>
+            <td><%= sale[:count] %></td>
+            <td><%= sale[:average] %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    
+    <%= paginate @sales %>
+  </div>
+</div>


### PR DESCRIPTION
## やったこと　
- 管理者用の売上管理機能を実装

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/dashboard_controller.rb` | 管理者用ダッシュボードのコントローラ編集 |
| `app/views/dashboard/index.html.erb` | 売上管理画面（ダッシュボードのトップページ）のビュー編集 |
| `app/models/shopping_cart.rb` | モデルにメソッド追加 |


## できるようになること（ユーザ目線）

* 管理者が売上一覧を見れるようになりました
* 売上は月別と日別で確認できます
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/d7396541-d8d3-4d7a-a6f1-02b1b00f7399)
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/289c95a3-6619-472a-9a4c-0db7a29d9c4a)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
