### PR TITLE
fest:送料計算機能の追加

### DIFF
--- a/app/controllers/dashboard/products_controller.rb
+++ b/app/controllers/dashboard/products_controller.rb
@@ -52,6 +52,6 @@ class Dashboard::ProductsController < ApplicationController
     end
 
     def product_params
-      params.require(:product).permit(:name, :description, :price, :category_id, :recommended_flag)
+      params.require(:product).permit(:name, :description, :price, :category_id, :recommended_flag, :carriage_flag)
     end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -41,6 +41,10 @@ class Product < ApplicationRecord
   scope :recommend_products, -> (number) { 
     where(recommended_flag: true).take(number)
     }
+    
+  scope :check_products_carriage_list, -> (product_ids) { 
+    where(id: product_ids).pluck(:carriage_flag)
+  }
   
   def reviews_new
     reviews.new

--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -27,6 +27,9 @@ class ShoppingCart < ApplicationRecord
      {"日別": "daily", "月別": "month"}
    }
   
+  CARRIAGE=800
+  FREE_SHIPPING=0
+  
   def self.get_monthly_sales
     if Rails.env.production?
       months = bought_months_mysql
@@ -81,5 +84,12 @@ class ShoppingCart < ApplicationRecord
   
   def tax_pct
     0
+  end
+  
+  def shipping_cost
+    product_ids = ShoppingCartItem.user_cart_item_ids(self.id)
+    products_carriage_list = Product.check_products_carriage_list(product_ids)
+    products_carriage_list.include?(true) ? Money.new(CARRIAGE * 100)
+                                          : Money.new(FREE_SHIPPING)
   end
 end

--- a/app/models/shopping_cart_item.rb
+++ b/app/models/shopping_cart_item.rb
@@ -2,4 +2,5 @@ class ShoppingCartItem < ApplicationRecord
     acts_as_shopping_cart_item
     
     scope :user_cart_items, -> (user_shoppingcart) { where(owner_id: user_shoppingcart) }
+    scope :user_cart_item_ids, -> (user_shoppingcart) { where(owner_id: user_shoppingcart).pluck(:item_id) }
 end

--- a/app/views/dashboard/products/edit.html.erb
+++ b/app/views/dashboard/products/edit.html.erb
@@ -26,6 +26,11 @@
       <%= f.label :recommended_flag, "オススメ?", class: "col-2 d-flex justify-content-start" %>
       <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
      </div>
+     
+    <div class="form-inline mt-4 mb-4 row ">
+      <%= f.label "送料", class: "col-2 d-flex justify-content-start" %>
+      <%= f.check_box :carriage_flag, class: "samuraimart-check-box" %>
+    </div>
 
     <%= f.submit "更新", class: "w-25 btn samuraimart-submit-button" %>
   <% end %>

--- a/app/views/dashboard/products/new.html.erb
+++ b/app/views/dashboard/products/new.html.erb
@@ -28,6 +28,11 @@
       <%= f.label "オススメ?", class: "col-2 d-flex justify-content-start" %>
       <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
     </div>
+    
+    <div class="form-inline mt-4 mb-4 row ">
+      <%= f.label "送料", class: "col-2 d-flex justify-content-start" %>
+      <%= f.check_box :carriage_flag, class: "samuraimart-check-box" %>
+    </div>
 
     <%= f.submit "商品を登録", class:"btn samuraimart-submit-button" %>
   <% end %>

--- a/app/views/shopping_carts/index.html.erb
+++ b/app/views/shopping_carts/index.html.erb
@@ -40,6 +40,22 @@
     <div class="offset-8 col-4">
       <div class="row">
         <div class="col-6">
+          <h3>小計</h3>
+        </div>
+        <div class="col-6">
+          <h3>￥<%= (@user_cart.total - @user_cart.shipping_cost).fractional / 100 %></h3>
+        </div>
+      </div>      
+      <div class="row">
+        <div class="col-6">
+          <h3>送料</h3>
+        </div>
+        <div class="col-6">
+          <h3>￥<%= @user_cart.shipping_cost.fractional / 100 %></h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-6">
           <h2>合計</h2>
         </div>
         <div class="col-6">

--- a/db/migrate/20240229061137_add_carriage_flag_to_products.rb
+++ b/db/migrate/20240229061137_add_carriage_flag_to_products.rb
@@ -1,0 +1,5 @@
+class AddCarriageFlagToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :carriage_flag, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_29_022148) do
+ActiveRecord::Schema.define(version: 2024_02_29_061137) do
 
   create_table "admins", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2024_02_29_022148) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "recommended_flag", default: false
+    t.boolean "carriage_flag", default: false
     t.index ["category_id"], name: "index_products_on_category_id"
   end
 


### PR DESCRIPTION
## やったこと　

- 送料計算機能の追加

| ファイル | 何をしたか |
| --- | --- |
|  `app/views/dashboard/products/edit.html.erb` | 商品編集にて送料がかかるか選択するチェックボックス追加 |
| `app/views/dashboard/products/new.html.erb` | 商品新規作成画面　編集 |
| `app/views/shopping_carts/index.html.erb` | ショッピングカート画面　編集 |
| `app/models/shopping_cart.rb`, `app/models/product.rb`, `app/models/shopping_cart_item.rb` | モデルにメソッドを追加|

## できるようになること（ユーザ目線）

- 商品ごとに送料（一律800円）がかかるかどうか選択できるように実装しました
- ショッピングカートに「小計、送料、合計」が表示されるようにしました
- 一つでも送料がかかる商品がある場合は送料+800円されるように実装しました

- 商品編集にて「アップル」の送料を有料に変更
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/50edda21-defb-4ed7-be8c-4665eed3e126)
- アップルをカートに追加した画面
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/813209e0-fa71-4aa6-88cb-8b67b1c2a594)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
