### PR TITLE
feat:画像アップロード機能の実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,4 +17,3 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
-//= require_tree .

--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/dashboard/categories.coffee
+++ b/app/assets/javascripts/dashboard/categories.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/dashboard/major_categories.coffee
+++ b/app/assets/javascripts/dashboard/major_categories.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/dashboard/products.coffee
+++ b/app/assets/javascripts/dashboard/products.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/dashboard/products/edit.js
+++ b/app/assets/javascripts/dashboard/products/edit.js
@@ -1,0 +1,10 @@
+function handleImage(image) {
+    let reader = new FileReader();
+    reader.onload = function() {
+      let imagePreview = document.getElementById("product-image-preview");
+      imagePreview.src = reader.result;
+      imagePreview.className += "img-fluid w-25";
+    };
+  console.log(image);
+  reader.readAsDataURL(image[0]);
+  }

--- a/app/assets/javascripts/dashboard/products/new.js
+++ b/app/assets/javascripts/dashboard/products/new.js
@@ -1,0 +1,10 @@
+function handleImage(image) {
+  let render = new FileReader();
+  render.onload = function() {
+    let imagePreview = document.getElementById("product-image-preview");
+    imagePreview.src = render.result;
+    imagePreview.className += "img-fluid w-25";
+  };
+  console.log(image);
+  render.readAsDataURL(image[0]);
+}

--- a/app/assets/javascripts/dashboard/users.coffee
+++ b/app/assets/javascripts/dashboard/users.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/products.coffee
+++ b/app/assets/javascripts/products.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/reviews.coffee
+++ b/app/assets/javascripts/reviews.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/shopping_carts.coffee
+++ b/app/assets/javascripts/shopping_carts.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/web.coffee
+++ b/app/assets/javascripts/web.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/controllers/dashboard/products_controller.rb
+++ b/app/controllers/dashboard/products_controller.rb
@@ -52,6 +52,6 @@ class Dashboard::ProductsController < ApplicationController
     end
 
     def product_params
-      params.require(:product).permit(:name, :description, :price, :category_id, :recommended_flag, :carriage_flag)
+      params.require(:product).permit(:name, :description, :price, :category_id, :recommended_flag, :carriage_flag, :image)
     end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,7 @@
 class Product < ApplicationRecord
   belongs_to :category
   has_many :reviews
+  has_one_attached :image
   acts_as_likeable
   
   extend DisplayList

--- a/app/views/dashboard/products/edit.html.erb
+++ b/app/views/dashboard/products/edit.html.erb
@@ -23,6 +23,20 @@
     </div>
     
     <div class="form-inline mt-4 mb-4 row">
+      <%= f.label "画像", class: "col-2 d-flex justify-content-start" %>
+      <% if @product.image.attached? %>
+        <%= image_tag @product.image, id: "product-image-preview", class: "img-fluid w-25" %>
+      <% else %>
+        <img src="#" id="product-image-preview" class="">
+      <% end %>
+      <div class="d-flex flex-column ml-2">
+        <small class="mb-3">600px×600px推奨。<br>商品の魅力が伝わる画像をアップロードして下さい。</small>
+        <%= f.label "画像を選択", for: "product_image", class: "btn samuraimart-submit-button" %>
+        <%= f.file_field :image, { onChange: "javascript: handleImage(this.files);", style: "display: none;"} %>
+      </div>
+    </div>
+    
+    <div class="form-inline mt-4 mb-4 row">
       <%= f.label :recommended_flag, "オススメ?", class: "col-2 d-flex justify-content-start" %>
       <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
      </div>
@@ -37,3 +51,5 @@
 
   <div class="mt-4"><%= link_to "商品一覧に戻る", dashboard_products_path %></div>
 </div>
+
+<%= javascript_include_tag "dashboard/products/edit" %>

--- a/app/views/dashboard/products/index.html.erb
+++ b/app/views/dashboard/products/index.html.erb
@@ -43,7 +43,13 @@
       <% @products.each do |product| %>
       <tr>
         <th scope="row"><%= product.id %></td>
-        <td><%= image_tag "/images/dummy.png", class: "h-10 img-fluid" %></td>
+        <td>
+          <% if product.image.attached? %>
+            <%= image_tag product.image, class: "h-10 img-fluid" %>
+          <% else %>
+            <%= image_tag "/images/dummy.png", class: "h-10 img-fluid" %>
+          <% end %>
+        </td>
         <td><%= product.name %></td>
         <td><%= product.price %></td>
         <td><%= product.category.name %></td>

--- a/app/views/dashboard/products/new.html.erb
+++ b/app/views/dashboard/products/new.html.erb
@@ -24,6 +24,20 @@
       <%= f.collection_select(:category_id, @categories, :id, :name, {}, class: "form-control") %>
     </div>
     
+    <div class="form-inline mt-4 mb-4 row">
+      <%= f.label "画像", class: "col-2 d-flex justify-content-start" %>
+      <% if @product.image.attached? %>
+        <%= image_tag @product.image, id: "product-image-preview", class: "img-fluid w-25" %>
+      <% else %>
+        <img src="#" id="product-image-preview" class="">
+      <% end %>
+      <div class="d-flex flex-column ml-2">
+        <small class="mb-3">600px×600px推奨。<br>商品の魅力が伝わる画像をアップロードして下さい。</small>
+        <%= f.label "画像を選択", for: "product_image", class: "btn samuraimart-submit-button" %>
+        <%= f.file_field :image, { onChange: "javascript: handleImage(this.files);", style: "display: none;"} %>
+      </div>
+    </div>
+    
     <div class="form-inline mt-4 mb-4 row ">
       <%= f.label "オススメ?", class: "col-2 d-flex justify-content-start" %>
       <%= f.check_box :recommended_flag, class: "samuraimart-check-box" %>
@@ -39,3 +53,5 @@
 
   <div class="mt-4"><%= link_to "商品一覧に戻る", dashboard_products_path %></div>
 </div>
+
+<%= javascript_include_tag "dashboard/products/new" %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -24,7 +24,11 @@
         <% @products.each do |product|%>
         <div class="col-3">
           <%= link_to product_path(product) do %>
-            <%= image_tag "/images/dummy.png", class: "img-thumbnail"%>
+            <% if product.image.attached? %>
+              <%= image_tag product.image, class: "img-thumbnail" %>
+            <% else %>
+              <%= image_tag "/images/dummy.png", class: "img-thumbnail" %>
+            <% end %>
           <% end %>
           <div class="row">
             <div class="col-12">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,7 +1,11 @@
 <div class="d-flex justify-content-center">
   <div class="row w-75">
     <div class="col-5 offset-1">
-      <%= image_tag "/images/dummy.png", class: "w-100 img-fuild" %>
+      <% if @product.image.attached? %>
+        <%= image_tag @product.image, class: "w-100 img-fuild" %>
+      <% else %>
+        <%= image_tag "/images/dummy.png", class: "w-100 img-fuild" %>
+      <% end %>
     </div>
 
     <div class="col">

--- a/app/views/shopping_carts/index.html.erb
+++ b/app/views/shopping_carts/index.html.erb
@@ -20,7 +20,11 @@
         <% product = Product.find(user_cart_item.item_id) %>
         <div class="col-md-2 mt-2">
           <%= link_to product_path(product) do %>
+            <% if product.image.attached? %>
+              <%= image_tag product.image, class: "img-fuild w-100" %>
+            <% else %>
               <%= image_tag "/images/dummy.png", class: "img-fuild w-100" %>
+            <% end %>
           <% end %>
         </div>
         <div class="col-md-6 mt-4">

--- a/app/views/users/favorite.html.erb
+++ b/app/views/users/favorite.html.erb
@@ -9,7 +9,11 @@
       <div class="col-md-8 mt-2">
         <div class="d-inline-flex">
           <%= link_to product_path(favorite), class: "w-25" do %>
-            <%= image_tag "/images/dummy.png", class: "img-fuild w-100" %>
+            <% if favorite.image.attached? %>
+              <%= image_tag favorite.image, class: "img-fuild w-100" %>
+            <% else %>
+              <%= image_tag "/images/dummy.png", class: "img-fuild w-100" %>
+            <% end %>
           <% end %>
           <div class="container mt-3">
             <h5 class="w-100 samuraimart-favorite-item-text"><%= favorite.name %></h5>

--- a/app/views/web/index.html.erb
+++ b/app/views/web/index.html.erb
@@ -27,7 +27,11 @@
         <% @recently_products.each do |recently_product| %>
         <div class="col-3">
           <%= link_to product_path(recently_product) do %>
-            <%= image_tag "/images/dummy.png", class: "img-thumbnail" %>
+            <% if recently_product.image.attached? %>
+              <%= image_tag recently_product.image, class: "img-thumbnail" %>
+            <% else %>
+              <%= image_tag "/images/dummy.png", class: "img-thumbnail" %>
+            <% end %>
           <% end %>
           <div class="row">
             <div class="col-12">

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( *.js )

--- a/db/migrate/20240229074809_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240229074809_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_02_29_061137) do
+ActiveRecord::Schema.define(version: 2024_02_29_074809) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
## やったこと　
- 商品画像をアップロードする機能の追加(Active Storage使用)
- jsファイルを個別で読み込むよう変更してます

| ファイル | 何をしたか |
| --- | --- |
| `app/views/dashboard/products/*` など編集した全ビューファイル| 商品が表示されるページ全て画像挿入部分変更 |
| `app/assets/javascripts/dashboard/*`| 画像アップロード用のJSファイル新規作成 |


## できるようになること（ユーザ目線）

* 商品の新規追加や編集で画像がフォルダからアップロードできるようになりました
* ユーザーは追加された画像もしくは`dummy.png`が商品画像として見れるようになりました
- 商品登録画面
![スクリーンショット 2024-02-29 17 59 55](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/d2b4050a-17ab-47bd-8c1b-9b31a56baeda)
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/beb0d0ee-2e70-4568-a85a-a4558c7a2496)
- 商品管理画面
![スクリーンショット 2024-02-29 18 01 36](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/8dce165c-e4f0-41c3-9875-209813196d80)
- ユーザーから見たトップ画面
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/3dbf6a1f-7cb3-4d21-9a45-f42c09679d49)
- 商品詳細画面
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/ca64d7f8-69bc-4772-8f4d-bf47c50b66d6)
- カート画面
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/eae23069-306c-4013-8600-0a5b4e3e218d)
- お気に入り画面
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/28c9d0ec-7adb-44dd-8839-74472c730437)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* エラーはないがお気に入り画面にて画像サイズが`dummy.png`とアップロードしたファイルとで異なる点が気になる

## その他

- なし
