### PR TITLE
feat:管理者用受注一覧画面の作成

### DIFF
--- a/app/assets/javascripts/dashboard/orders.coffee
+++ b/app/assets/javascripts/dashboard/orders.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/dashboard/orders.scss
+++ b/app/assets/stylesheets/dashboard/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the dashboard/orders controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/dashboard/orders_controller.rb
+++ b/app/controllers/dashboard/orders_controller.rb
@@ -1,0 +1,12 @@
+class Dashboard::OrdersController < ApplicationController
+  before_action :authenticate_admin!
+  layout "dashboard/dashboard"
+  
+  def index
+    if params[:code].present?
+      @orders = ShoppingCart.search_bought_carts_by_ids(params[:code]).page(params[:page]).per(15)
+    else
+      @orders = ShoppingCart.bought_carts.page(params[:page]).per(15)
+    end 
+  end
+end

--- a/app/helpers/dashboard/orders_helper.rb
+++ b/app/helpers/dashboard/orders_helper.rb
@@ -1,0 +1,2 @@
+module Dashboard::OrdersHelper
+end

--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -23,6 +23,9 @@ class ShoppingCart < ApplicationRecord
   scope :search_bought_carts_by_month, -> (month) { bought_carts.where(updated_at: month.all_month) }
   scope :search_bought_carts_by_day, -> (day) { bought_carts.where(updated_at: day.all_day) }
   
+  scope :search_carts_by_ids, -> (ids) { where("id LIKE ?", "%#{ids}%") }
+  scope :search_bought_carts_by_ids, -> (ids) { bought_carts.search_carts_by_ids(ids) }
+   
   scope :sort_list, -> {
      {"日別": "daily", "月別": "month"}
    }

--- a/app/views/dashboard/orders/index.html.erb
+++ b/app/views/dashboard/orders/index.html.erb
@@ -1,0 +1,37 @@
+<div class="w-75">
+  <h1>受注一覧</h1>
+  <div class="w-75">
+    <%= form_with url: dashboard_orders_path, method: :get, local: true do |f| %>
+      <div class="d-flex flex-inline form-group">
+        <div class="d-flex align-items-center">
+          注文番号
+        </div>
+        <%= f.text_field :code, value: @code, class: "form-controll ml-2 w-50", placeholder: "12345678" %>
+      </div>
+      <%= f.submit "検索", class: "btn samuraimart-submit-button" %>
+    <% end %>
+  </div>
+
+  <table class="table mt-5">
+    <thead>
+      <tr>
+        <th scope="col" class="w-25">注文番号</th>
+        <th scope="col">注文者名</th>
+        <th scope="col">注文日時</th>
+        <th scope="col">購入金額</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @orders.each do |order| %>
+      <tr>
+        <td class="align-middle" scope="row"><%= order.id %></td>
+        <td class="align-middle"><%= User.find(order.user_id).name %></td>
+        <td class="align-middle"><%= order.updated_at.to_datetime.strftime("%Y-%m-%d %H:%M:%S") %></td>
+        <td class="align-middle"><%= order.total.fractional / 100 %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @orders %>
+</div>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -1,8 +1,9 @@
 <div class="container ml-3">
   <h2>受注管理</h2>
   <div class="d-flex flex-column">
-    <label class="samuraimart-sidebar-category-label">受注一覧</label>
-    <label class="samuraimart-sidebar-category-label">受注登録</label>
+    <label class="samuraimart-sidebar-category-label">
+      <%= link_to "受注一覧", dashboard_orders_path %>
+    </label>    
   </div>
 
   <h2>商品管理</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     resources :categories, except: [:new]
     resources :products, except: [:show]
     resources :users, only: [:index, :destroy]
+    resources :orders, only: [:index]
   end
   
   devise_for :users, :controllers => {

--- a/test/controllers/dashboard/orders_controller_test.rb
+++ b/test/controllers/dashboard/orders_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Dashboard::OrdersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと　
- 管理者が受注管理できるよう下記ファイルを編集

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/dashboard/orders_controller.rb` | 受注管理用コントローラ新規作成 |
| `app/views/dashboard/orders/index.html.erb` | 受注管理画面新規作成 |
| `config/routes.rb` | ルート編集 |
| `app/models/shopping_cart.rb` | メソッド追加 |


## できるようになること（ユーザ目線）

* 管理者が受注一覧から受注番号から受注検索できるようになりました
* サイドバーから「受注一覧」へ飛べるようになりました
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/7b03fec1-cd16-42ca-8ce2-90f3650df690)
- 受注番号「8」で検索かけた結果
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/d114fcbc-6976-46f2-a435-9d54b4be942e)


## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
