### PR TITLE
feat:CSVで商品を追加する機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :tag => 'v2.19.0
 
 gem 'acts_as_shopping_cart'
 
+gem 'activerecord-import'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       activemodel (= 5.2.4.2)
       activesupport (= 5.2.4.2)
       arel (>= 9.0)
+    activerecord-import (1.5.1)
+      activerecord (>= 4.2)
     activestorage (5.2.4.2)
       actionpack (= 5.2.4.2)
       activerecord (= 5.2.4.2)
@@ -288,6 +290,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   acts_as_shopping_cart
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.6.0)

--- a/app/assets/javascripts/dashboard/products/import.js
+++ b/app/assets/javascripts/dashboard/products/import.js
@@ -1,0 +1,10 @@
+  function handleCSV(csv) {
+    let reader = new FileReader();
+    reader.onload = function() {
+      let csvName = document.getElementById("product-import-csv-filename");
+      console.log(reader)
+      csvName.innerHTML = csv[0].name;
+    }
+    console.log(csv);
+    reader.readAsDataURL(csv[0]);
+  }

--- a/app/assets/stylesheets/samuraimart.scss
+++ b/app/assets/stylesheets/samuraimart.scss
@@ -267,3 +267,10 @@ td{
   border-radius: 2px;
   background-color: #d94b0e;
 }
+
+//CSV
+.samuraimart-button {
+  border-radius: 2px;
+  border: solid 1px #b2b2b2;
+  background-color: #ffffff;
+}

--- a/app/controllers/dashboard/products_controller.rb
+++ b/app/controllers/dashboard/products_controller.rb
@@ -1,3 +1,5 @@
+require 'nkf'
+
 class Dashboard::ProductsController < ApplicationController
   before_action :authenticate_admin!
   before_action :set_product, only: %w[edit update destroy]
@@ -44,6 +46,28 @@ class Dashboard::ProductsController < ApplicationController
   def destroy
     @product.destroy
     redirect_to dashboard_products_path
+  end
+  
+  def import
+  end
+ 
+  def import_csv
+    if params[:file] && File.extname(params[:file].original_filename) == ".csv"
+      Product.import_csv(params[:file])
+      flash[:success] = "CSVでの一括登録が成功しました!"
+      redirect_to import_csv_dashboard_products_url
+    else
+      flash[:danger] = "CSVが追加されていません。CSVを追加してください。"
+      redirect_to import_csv_dashboard_products_url
+    end
+  end
+ 
+  def download_csv
+    send_file(
+      "#{Rails.root}/public/csv/products.csv",
+      filename: "products.csv",
+      type: :csv
+    )
   end
 
   private

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -47,6 +47,30 @@ class Product < ApplicationRecord
     where(id: product_ids).pluck(:carriage_flag)
   }
   
+  def self.import_csv(file)
+    new_products = []
+    update_products = []
+    # CSV.foreach(file.path, headers: true, encoding: "Shift_JIS:UTF-8") do |row|
+    CSV.parse(NKF.nkf('-w', file.read), headers: true).each do |row|
+      row_to_hash = row.to_hash
+      # byebug
+      if row_to_hash[:id].present?
+        update_product = find(id: row_to_hash[:id])
+        update_product.attributes = row.to_hash.slice!(csv_attributes)
+        update_products << update_product
+      else
+        new_product = new
+        new_product.attributes = row.to_hash.slice!(csv_attributes)
+        new_products << new_product
+      end
+    end
+    if update_products.present?
+      import update_products, on_duplicate_key_update: csv_attributes
+    elsif new_products.present?
+      import new_products
+    end
+  end
+  
   def reviews_new
     reviews.new
   end
@@ -54,4 +78,9 @@ class Product < ApplicationRecord
   def reviews_with_id
      reviews.reviews_with_id
   end
+  
+  private
+    def self.csv_attributes
+      [:name, :description, :price, :recommended_flag, :carriage_flag]
+    end
 end

--- a/app/views/dashboard/products/edit.html.erb
+++ b/app/views/dashboard/products/edit.html.erb
@@ -19,7 +19,7 @@
 
     <div class="form-inline mt-4 mb-4 row">
       <%= f.label :category_id, "カテゴリ", class: "col-2 d-flex justify-content-start" %>
-      <%= f.select :category_id, Category.all.map { |category| [category.name, category.id] }, {}, class: "form-control" %>
+      <%= f.select :category_id, @categories.map { |category| [category.name, category.id] }, {}, class: "form-control" %>
     </div>
     
     <div class="form-inline mt-4 mb-4 row">

--- a/app/views/dashboard/products/import.html.erb
+++ b/app/views/dashboard/products/import.html.erb
@@ -1,0 +1,49 @@
+<% if flash[:success] %><p class="alert alert-success w-75"><%= flash[:success] %></p><% end %>
+<% if flash[:danger] %><p class="alert alert-danger w-75"><%= flash[:danger] %></p><% end %>
+<div class="w-75">
+  <h1>商品CSV登録</h1>
+  <%= form_with model: @product, url: import_csv_dashboard_products_path, local: true do |f| %>
+    <div class="d-flex flex-column">
+      <div class="d-flex flex-row">
+        <%= f.label "CSVファイルを選択", for: "file" ,class: "btn samuraimart-button mr-3 mb-0" %>
+        <%= f.file_field :file, onChange: "handleCSV(this.files)",style: "display: none;" %>
+        <%= f.submit "一括登録", class: "btn samuraimart-submit-button" %>
+      </div>
+    </div>
+    <small id="product-import-csv-filename"></small>
+  <% end %>
+
+  <div class="d-flex justify-content-between mt-3">
+    <h4 class="d-flex align-self-center mt-1 mb-0">CSVファイルフォーマット</h4>
+    <%= link_to "雛形ファイルダウンロード", import_csv_download_dashboard_products_path, class: "btn samuraimart-button" %>
+  </div>
+
+  <hr>
+
+  <div class="row">
+    <label class="col-3">商品ID</label>
+    <span class="col-9">新規登録の場合は空にしてください。既存の商品を更新する場合は、商品IDを指定してください。</span>
+
+    <label class="col-3">商品名</label>
+    <span class="col-9"></span>
+
+    <label class="col-3">商品説明</label>
+    <span class="col-9"></span>
+
+    <label class="col-3">価格</label>
+    <span class="col-9"></span>
+
+    <label class="col-3">カテゴリID</label>
+    <span class="col-9"></span>
+
+    <label class="col-3">オススメ商品フラグ</label>
+    <span class="col-9"></span>
+
+    <label class="col-3">送料フラグ</label>
+    <span class="col-9"></span>
+  </div>
+
+  <hr>
+</div>
+
+<%= javascript_include_tag "dashboard/products/import" %>

--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -17,7 +17,9 @@
     <label class="samuraimart-sidebar-category-label">
        <%= link_to "カテゴリ管理", dashboard_categories_path %>
      </label>
-    <label class="samuraimart-sidebar-category-label">CSV一括登録</label>
+    <label class="samuraimart-sidebar-category-label">
+       <%= link_to "CSV一括登録", import_csv_dashboard_products_path %>
+     </label>
   </div>
 
   <h2>顧客管理</h2>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'csv'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,13 @@ Rails.application.routes.draw do
     resources :products, except: [:show]
     resources :users, only: [:index, :destroy]
     resources :orders, only: [:index]
+    resources :products, except: [:show] do
+      collection do
+        get  "import/csv", :to => "products#import"
+        post "import/csv", :to => "products#import_csv"
+        get  "import/csv_download", :to => "products#download_csv"
+      end
+    end
   end
   
   devise_for :users, :controllers => {

--- a/public/csv/products.csv
+++ b/public/csv/products.csv
@@ -1,0 +1,1 @@
+name,description,price,category_id,recommended_flag,carriage_flag,


### PR DESCRIPTION
## やったこと　
- 管理者がCSVファイルのインポートから商品を新規追加できるように実装しました
- `require 'csv'`、`require 'nkf'`してます

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/dashboard/products_controller.rb` | ダッシュボードの商品コントローラ編集 |
| `app/models/product.rb` | 商品のモデル編集 （CSV処理追加）|
| `app/views/dashboard/products/import.html.erb` |CSVインポート画面新規作成 |
| `config/routes.rb` | ルート編集 |
| `public/csv/products.csv` | CSVファイルの雛形 |


## できるようになること（ユーザ目線）

* 管理者がCSVファイルを用いて商品を一括で新規作成できるようになりました
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/69b11f43-977f-4e05-84e9-a05826f5dce9)
- ファイルを選択するとファイル名が小さく表示
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/d0fa187d-d4db-4b7e-afc7-18b656454a79)
- 登録完了すると成功のフラッシュが表示
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/58e39000-491a-4cc9-8c82-3da96e76e5db)
- 今回のCSVファイルの中身
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/1d9bb646-9509-4186-8303-472c9d68602d)
- 追加された商品2つ(ユーザー側の画面でも無事表示されました)
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/c8939f8a-c195-4119-89f3-4bafa9bfd702)
- 失敗のフラッシュ
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/d2358ddf-290b-4532-92df-333a2ca45f6a)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
