### PR TITLE
frat:注文履歴一覧画面の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,6 +40,15 @@ class UsersController < ApplicationController
     @user.update(deleted_flg: @user.deleted_flg)
     redirect_to root_url
   end
+  
+  def cart_history_index
+    @orders = ShoppingCart.search_bought_carts_by_user(@user).page(params[:page]).per(15)
+  end
+  
+  def cart_history_show
+    @cart = ShoppingCart.find(params[:num])
+    @cart_items = ShoppingCartItem.user_cart_items(@cart.id)
+  end
 
   private
     def set_user

--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -25,6 +25,9 @@ class ShoppingCart < ApplicationRecord
   
   scope :search_carts_by_ids, -> (ids) { where("id LIKE ?", "%#{ids}%") }
   scope :search_bought_carts_by_ids, -> (ids) { bought_carts.search_carts_by_ids(ids) }
+  
+  scope :search_carts_by_user, -> (user) { where(user_id: user) }
+  scope :search_bought_carts_by_user, -> (user) { bought_carts.search_carts_by_user(user) }
    
   scope :sort_list, -> {
      {"日別": "daily", "月別": "month"}

--- a/app/views/users/cart_history_index.html.erb
+++ b/app/views/users/cart_history_index.html.erb
@@ -1,0 +1,35 @@
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <span>
+        <%= link_to "マイページ", mypage_users_path %> > 注文履歴
+      </span>
+
+      <div class="container mt-4">
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">注文番号</th>
+              <th scope="col">購入日時</th>
+              <th scope="col">合計金額</th>
+              <th scope="col">詳細</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @orders.each do |order| %>
+            <tr>
+              <td><%= order.id %></td>
+              <td><%= order.updated_at.to_datetime.strftime("%Y-%m-%d %H:%M:%S") %></td>
+              <td><%= order.total.fractional / 100 %></td>
+              <td>
+                <%= link_to "#{ order.id }", mypage_cart_history_users_path(order) %>
+              </td>
+            </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <%= paginate @orders %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/cart_history_show.html.erb
+++ b/app/views/users/cart_history_show.html.erb
@@ -1,0 +1,97 @@
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <span>
+        <%= link_to "マイページ", mypage_users_path %> > <%= link_to "注文履歴", mypage_cart_histories_users_path %> > 注文履歴詳細
+      </span>
+
+      <h1 class="mt-3">注文履歴詳細</h1>
+
+      <h4 class="mt-3">ご注文情報</h4>
+
+      <hr>
+
+      <div class="row">
+        <div class="col-5 mt-2">
+          注文番号
+        </div>
+        <div class="col-7 mt-2">
+          <%= @cart.id %>
+        </div>
+
+        <div class="col-5 mt-2">
+          注文日時
+        </div>
+        <div class="col-7 mt-2">
+          <%= @cart.updated_at.strftime("%Y-%m-%d %H:%M:%S") %>
+        </div>
+        
+        <div class="col-5 mt-2">
+          商品の小計
+        </div>
+        <div class="col-7 mt-2">
+          ￥<%= (@cart.total - @cart.shipping_cost).fractional / 100 %>
+        </div>    
+        
+        <div class="col-5 mt-2">
+          送料
+        </div>
+        <div class="col-7 mt-2">
+          ￥<%= @cart.shipping_cost.fractional / 100 %>
+        </div>        
+
+        <div class="col-5 mt-2">
+          合計金額
+        </div>
+        <div class="col-7 mt-2">
+          ￥<%= @cart.total.fractional / 100 %>
+        </div>
+
+        <div class="col-5 mt-2">
+          点数
+        </div>
+        <div class="col-7 mt-2">
+          <%= ShoppingCartItem.user_cart_items(@cart.id).count %>点
+        </div>
+
+      </div>
+
+      <hr>
+
+      <div class="row">
+        <% @cart_items.each do |cart_item| %>
+          <% product = Product.find(cart_item.item_id) %>
+          <div class="col-md-5 mt-2">
+            <%= link_to product_path(product), class: "ml-4" do %>
+              <% if product.image.attached? %>
+                <%= image_tag product.image, class: "img-fuild w-75" %>
+              <% else %>
+                <%= image_tag "/images/dummy.png", class: "img-fuild w-75" %>
+              <% end %>            
+            <% end %>
+          </div>
+          <div class="col-md-7 mt-2">
+            <div class="flex-cloumn">
+              <p class="mt-4"><%= product.name %></p>
+              <div class="row">
+                <div class="col-2 mt-2">
+                  数量
+                </div>
+                <div class="col-10 mt-2">
+                  <%= cart_item.quantity %>
+                </div>
+  
+                <div class="col-2 mt-2">
+                  小計
+                </div>
+                <div class="col-10 mt-2">
+                  ￥<%= price = cart_item.price_cents * cart_item.quantity %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -42,7 +42,7 @@
           </div>
         </div>
         <div class="d-flex align-items-center">
-          <%= link_to mypage_users_path do %>
+          <%= link_to mypage_cart_histories_users_path do %>
             <i class="fas fa-chevron-right fa-2x"></i>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
   }
  
   devise_scope :admin do
-    get "dashboard", :to => "dashboard#index"
-    get "dashboard/login", :to => "admins/sessions#new"
-    post "dashboard/login", :to => "admins/sessions#create"
+    get "dashboard",           :to => "dashboard#index"
+    get "dashboard/login",     :to => "admins/sessions#new"
+    post "dashboard/login",    :to => "admins/sessions#create"
     delete "dashboard/logout", :to => "admins/sessions#destroy"
   end
   
@@ -19,8 +19,8 @@ Rails.application.routes.draw do
     resources :orders, only: [:index]
     resources :products, except: [:show] do
       collection do
-        get  "import/csv", :to => "products#import"
-        post "import/csv", :to => "products#import_csv"
+        get  "import/csv",          :to => "products#import"
+        post "import/csv",          :to => "products#import_csv"
         get  "import/csv_download", :to => "products#download_csv"
       end
     end
@@ -36,25 +36,27 @@ Rails.application.routes.draw do
 
 devise_scope :user do
   root :to => "web#index"
-  get "signup", :to => "users/registrations#new"
-  get "verify", :to => "users/registrations#verify"
-  get "login", :to => "users/sessions#new"
+  get "signup",    :to => "users/registrations#new"
+  get "verify",    :to => "users/registrations#verify"
+  get "login",     :to => "users/sessions#new"
   delete "logout", :to => "users/sessions#destroy"
 end
 
 resource :users, only: [:edit, :update] do
   collection do
-    get "cart", :to => "shopping_carts#index"
-    post   "cart/create", :to => "shopping_carts#create"
-    delete "cart", :to => "shopping_carts#destroy"
-    get "mypage", :to => "users#mypage"
-    get "mypage/edit", :to => "users#edit"
-    get "mypage/address/edit", :to => "users#edit_address"
-    put "mypage", :to => "users#update"
-    get "mypage/edit_password", :to =>"users#edit_password"
-    put "mypage/password", :to => "users#update_password"
-    get  "mypage/favorite", :to => "users#favorite"
-    delete "mypage/delete", :to => "users#destroy"
+    get "cart",                        :to => "shopping_carts#index"
+    post   "cart/create",              :to => "shopping_carts#create"
+    delete "cart",                     :to => "shopping_carts#destroy"
+    get "mypage",                      :to => "users#mypage"
+    get "mypage/edit",                 :to => "users#edit"
+    get "mypage/address/edit",         :to => "users#edit_address"
+    put "mypage",                      :to => "users#update"
+    get "mypage/edit_password",        :to =>"users#edit_password"
+    put "mypage/password",             :to => "users#update_password"
+    get  "mypage/favorite",            :to => "users#favorite"
+    delete "mypage/delete",            :to => "users#destroy"
+    get "mypage/cart_history",         :to => "users#cart_history_index", :as => "mypage_cart_histories"
+    get "mypage/cart_history/[:num]",  :to => "users#cart_history_show", :as => "mypage_cart_history"
   end
 end
 


### PR DESCRIPTION
## やったこと　
- ユーザーが注文履歴の一覧と詳細を閲覧できるよう下記ファイルを編集

| ファイル | 何をしたか |
| --- | --- |
|  `app/controllers/users_controller.rb` | 注文履歴用コントローラ　新規作成 |
| `app/views/users/cart_history_index.html.erb` | 注文履歴一覧画面　新規作成 |
| `app/views/users/cart_history_show.html.erb` | 注文履歴詳細画面　新規作成 |
| `config/routes.rb` | ルート編集 |
| `app/models/shopping_cart.rb` | メソッド追加 |

## できるようになること（ユーザ目線）

* ユーザーが注文履歴を閲覧できるようになりました
- 注文履歴一覧ページ
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/379f4cbd-1692-472c-bd22-432e9720e704)
- 注文履歴詳細ページ
![image](https://github.com/yume-ebina/SAMURAIMART/assets/147839715/0cfedbed-d7b5-4b46-8a0d-0dda54a87a49)

## 今回の実装でできなくなったこと（ユーザ目線）

* なし

## 動作確認

* 問題なし

## その他

- なし
